### PR TITLE
checkScriptSyntax do not return the correct object

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -287,7 +287,7 @@ Doc.prototype.setScript = function(Script) {
 };
 Doc.prototype.checkScriptSyntax = function() {
     return this.connection.ask(this.handle, 'CheckScriptSyntax', arguments).then(function(msg) {
-        return msg.qErrorList;
+        return msg.qErrors;
     });
 };
 Doc.prototype.getDirectoryListing = function(Connection, RelativePath, Path) {

--- a/qsocks.bundle.js
+++ b/qsocks.bundle.js
@@ -789,7 +789,7 @@ Doc.prototype.setScript = function(Script) {
 };
 Doc.prototype.checkScriptSyntax = function() {
     return this.connection.ask(this.handle, 'CheckScriptSyntax', arguments).then(function(msg) {
-        return msg.qErrorList;
+        return msg.qErrors;
     });
 };
 Doc.prototype.getDirectoryListing = function(Connection, RelativePath, Path) {


### PR DESCRIPTION
checkScriptSyntax response don't have msg.qErrorList object. The api return msg.Errors instead.