### PR TITLE
better check for node

### DIFF
--- a/qsocks.js
+++ b/qsocks.js
@@ -10,7 +10,7 @@ var genericVariable = require('./lib/genericVariable');
 var Promise = require('promise');
 
 var VERSION = '3.0.4';
-var IS_NODE = typeof process !== "undefined" && Object.prototype.toString.call(process) === "[object process]";
+var IS_NODE = typeof process !== "undefined" && Object.prototype.toString.call(global.process) === "[object process]";
 
 // ws 1.0.1 breaks in browser. This will fallback to browser versions correctly
 var WebSocket = global.WebSocket || global.MozWebSocket;


### PR DESCRIPTION
This check will work regardless of a process shim. 

If in browser, Object.prototype.toString.call(global.process) -> “[object Undefined]”

If in node, returns “[object process]”